### PR TITLE
Prevent infinite loop on canceling order

### DIFF
--- a/Extend/Application/Model/Order.php
+++ b/Extend/Application/Model/Order.php
@@ -258,7 +258,7 @@ class Order extends Order_parent
         $oPaymentCancel = oxNew(PaymentCancel::class);
         $oPaymentCancel->sendRequest($this);
 
-        $this->cancelOrder();
+        parent::cancelOrder();
     }
 
     /**


### PR DESCRIPTION
Method calls itself again and again. I think the intention was to call the parent method to not break the inheritance compatibility.

Fixes #2 